### PR TITLE
swap sudo with --user for pip install section of README docs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ remotes::install_github("dgrtwo/knowledgerepo")
 You'll also need to install the [knowledge_repo](https://github.com/airbnb/knowledge-repo) Python package from your terminal.
 
 ```
-[sudo] pip install --upgrade knowledge-repo
+pip install --upgrade [--user] knowledge-repo
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ remotes::install_github("dgrtwo/knowledgerepo")
 You'll also need to install the [knowledge_repo](https://github.com/airbnb/knowledge-repo) Python package from your terminal.
 
 ```
-[sudo] pip install --upgrade knowledge-repo
+pip install --upgrade [--user] knowledge-repo
 ```
 
 ## Usage


### PR DESCRIPTION
Instead of using `sudo` to install python dependencies, adding the `--user` flag  is the safer and generally more preferred way. 